### PR TITLE
Fix capitals of api path in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
 
   explorer_trial_api:
     build:
-      context: ./StemExplorerApi
+      context: ./StemExplorerAPI
     environment:
       - ASPNETCORE_URLS=http://+:5000
       - ASPNETCORE_ENVIRONMENT=Development


### PR DESCRIPTION
The StemExplorerAPI folder name was spelt with lowercase letters in docker-compose.yml, (`StemExplorerApi`) and with capitals everywhere else (`StemExplorerAPI`). This was not a problem on Windows and macOS as their filesystems do not care about the case of filenames, but on OSes with case-sensitive filesystems (such as Linux), it could cause docker-compose to crash.

This PR changes the lowercase letters in docker-compose.yml to match the uppercase letters present everywhere else.