### PR TITLE
UI Live Updates

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+version: '3.1'
+
+services:
+  explorer_trial_ui:
+    build:
+      context: ./stem-explorer-ng
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./stem-explorer-ng/src:/var/www/app/src
+    ports:
+      - "4200:4200"
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,18 @@
+# This config can be used as an alternative to the explorer_trial_ui config in
+# docker-compose.yml.
+#
+# The default config (in docker-compose.yml) builds the application when the
+# image is built, and then only runs an http server in the final image, which
+# means that changes to the code require a restart. This config gets around
+# that by using `ng serve`, which is a command in the angular cli that rebuilds
+# and reloads the page when the source code is changed.
+#
+# To use this config run:
+# docker-compose -f docker-compose.dev.yml up --build
+#
+# Or to run the api server at the same time:
+# docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+
 version: '3.1'
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
     ports:
       - '4200:4200'
 
-
 volumes:
   mongodb-data:
     external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,12 @@ services:
   explorer_trial_ui:
     build:
       context: ./stem-explorer-ng
+      dockerfile: Dockerfile.dev
     environment:
       - PORT=4200
       - API_ENDPOINT=http://localhost:5000/api
     ports:
-      - '4200:4200'
+      - "4200:4200"
 
 volumes:
   mongodb-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,14 +24,12 @@ services:
   explorer_trial_ui:
     build:
       context: ./stem-explorer-ng
-      dockerfile: Dockerfile.dev
     environment:
       - PORT=4200
       - API_ENDPOINT=http://localhost:5000/api
-    volumes:
-      - ./stem-explorer-ng/src:/var/www/app/src
     ports:
-      - "4200:4200"
+      - '4200:4200'
+
 
 volumes:
   mongodb-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     environment:
       - PORT=4200
       - API_ENDPOINT=http://localhost:5000/api
+    volumes:
+      - ./stem-explorer-ng/src:/var/www/app/src
     ports:
       - "4200:4200"
 

--- a/stem-explorer-ng/Dockerfile.dev
+++ b/stem-explorer-ng/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM node:10 AS runtime-stage
+
+ENV TERM=xterm
+ENV ROOT /var/www/app
+
+WORKDIR $ROOT
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 4200
+
+# --host=0.0.0.0 is required to access the server from outside of the docker container
+# See https://stackoverflow.com/a/43492433/10530876
+CMD npm run start -- --host=0.0.0.0


### PR DESCRIPTION
At the moment you can run both the back end and front-end at once, but you need to rebuild the containers every time you make a change.

Using `ng serve` would mean that anytime you make a change to the front end code, it will update and you do not need to rebuild the containers.

In order for `ng serve` to work with Docker, I needed to pass the `--host=0.0.0.0` flag, which tells the server to listen to requests from other computers, not just the one that it is running on. This causes a warning saying that the development server has not been checked for use exposed to the internet, but the chances of a vulnerability are probably pretty slim and it will be inside of a Docker container and behind the network's firewall.