### PR TITLE
Change the way that the Fabs are positioned to avoid covering content

### DIFF
--- a/stem-explorer-ng/src/app/_variables.scss
+++ b/stem-explorer-ng/src/app/_variables.scss
@@ -39,3 +39,5 @@ $secondary-light-orange: #FCEAD7;
 @function tint($percentage, $color) {
   @return mix($color, white, $percentage);
 }
+
+$fab-padding: 1rem;

--- a/stem-explorer-ng/src/app/app.component.html
+++ b/stem-explorer-ng/src/app/app.component.html
@@ -6,9 +6,8 @@
 
   <router-outlet></router-outlet>
 
-  <app-fab-container *ngIf="isMap | async; else genericFab">
+  <app-fab-container *ngIf="isMap | async; else genericFab" class="no-height">
     <app-fab matIcon="list" (click)="navigateToList()"></app-fab>
-    <span class="fill-remaining-space"></span>
     <app-camera-button></app-camera-button>
   </app-fab-container>
   <ng-template #genericFab>

--- a/stem-explorer-ng/src/app/app.component.scss
+++ b/stem-explorer-ng/src/app/app.component.scss
@@ -1,3 +1,0 @@
-.fill-remaining-space {
-  flex: 1;
-}

--- a/stem-explorer-ng/src/app/containers/camera-button/camera-button.component.html
+++ b/stem-explorer-ng/src/app/containers/camera-button/camera-button.component.html
@@ -1,1 +1,1 @@
-<app-fab matIcon="camera_alt" (click)="cameraView()"></app-fab>
+<app-fab matIcon="camera_alt" (click)="cameraView()" position="right"></app-fab>

--- a/stem-explorer-ng/src/app/shared/components/fab-container/fab-container.component.scss
+++ b/stem-explorer-ng/src/app/shared/components/fab-container/fab-container.component.scss
@@ -1,12 +1,12 @@
+@use 'src/app/variables' as *;
+
 :host {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
+  display: block;
+  height: 56px;
+  margin: $fab-padding;
 
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-
-  padding: 1rem;
+  &.no-height {
+    height: 0;
+    margin: 0;
+  }
 }

--- a/stem-explorer-ng/src/app/shared/components/fab/fab.component.html
+++ b/stem-explorer-ng/src/app/shared/components/fab/fab.component.html
@@ -1,3 +1,3 @@
-<button mat-fab>
+<button mat-fab [class]="position">
   <mat-icon>{{ matIcon || 'menu' }}</mat-icon>
 </button>

--- a/stem-explorer-ng/src/app/shared/components/fab/fab.component.scss
+++ b/stem-explorer-ng/src/app/shared/components/fab/fab.component.scss
@@ -2,4 +2,15 @@
 
 button.mat-fab {
   background: tint(80%, $primary-black);
+
+  position: fixed;
+  bottom: $fab-padding;
+
+  &.left {
+    left: $fab-padding;
+  }
+
+  &.right {
+    right: $fab-padding;
+  }
 }

--- a/stem-explorer-ng/src/app/shared/components/fab/fab.component.ts
+++ b/stem-explorer-ng/src/app/shared/components/fab/fab.component.ts
@@ -8,6 +8,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 export class FabComponent {
 
   @Input() matIcon?: string;
+  @Input() position: 'right' | 'left' = 'left';
 
   constructor() { }
 


### PR DESCRIPTION
With the old way of placing the Fab buttons, the container would sometimes overlap content at the bottom of the screen. It would not stop the user from viewing the content, but it would stop them from clicking on buttons at the bottom of the screen (eg the hint button).

This change allows the user to interact with content that is outiside of the Fab button's hitbox, but would've been underneath the Fab Container. It also allows the user to scroll enough so that they can see all of the content.