### PR TITLE
Fix build errors compiling backend

### DIFF
--- a/StemExplorerAPI/StemExplorerAPI/Models/Entities/ChallengeLevel.cs
+++ b/StemExplorerAPI/StemExplorerAPI/Models/Entities/ChallengeLevel.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace StemExplorerAPI.Models.Entities
 {
-    public class ChallengeDifficulty
+    public class ChallengeLevel
     {
         public int Id { get; set; }
         public string QuestionText { get; set; }


### PR DESCRIPTION
Revert the name of the ChallengeLevel class back to ChallengeLevel. [The card that this was changed for](https://trello.com/c/PF3pleAs) states that the goal was that the two different ChallengeLevel types had different names.

I do not know how a build error managed to get merged. We should bring it up at the retro.