### PR TITLE
Fix challenge not loading due to changed id field name

### DIFF
--- a/StemExplorerAPI/StemExplorerAPI/Models/ViewModels/ChallengeDto.cs
+++ b/StemExplorerAPI/StemExplorerAPI/Models/ViewModels/ChallengeDto.cs
@@ -9,7 +9,6 @@ namespace StemExplorerAPI.Models.ViewModels
 {
     public class ChallengeDto
     {
-        [JsonPropertyName("uid")]
         public int Id { get; set; }
         public string Title { get; set; }
         public string Description { get; set; }

--- a/stem-explorer-ng/src/app/shared/models/challenge.ts
+++ b/stem-explorer-ng/src/app/shared/models/challenge.ts
@@ -1,5 +1,5 @@
 export interface Challenge {
-    uid: number;
+    id: number;
     title: string;
     description: string;
     category: number;

--- a/stem-explorer-ng/src/app/store/challenges/challenges.state.ts
+++ b/stem-explorer-ng/src/app/store/challenges/challenges.state.ts
@@ -37,7 +37,7 @@ export class ChallengesState {
       [ChallengesState],
       (challengeId: number): Challenge => {
         return state.challenges.find(
-          (challenge) => challenge.uid === challengeId,
+          (challenge) => challenge.id === challengeId,
         );
       },
     );


### PR DESCRIPTION
When the JSON library for the backend was changed from System.Json to Newtonsoft.Json, the old attributes that changed the property names stopped working. For example, this meant that all JSON properties that were called "uid" are now called "id".

This stopped the /challenge routes from loading. There are other areas that need tidying up but this was the only one that I know of that surfaced as a bug.