### PR TITLE
fix db-seed

### DIFF
--- a/db-seed.sh
+++ b/db-seed.sh
@@ -10,13 +10,13 @@ psql -d StemExplorer -U stem << EOF
 
 INSERT INTO "Locations" ("LocationId", "Name", "Latitude", "Longitude", "GooglePlaceId", "Url", "Phone", "Email")
 VALUES (1, 'Basestation', -37.6865807, 176.1649332, 'ChIJ905i8dzbbW0RIvN_2Wp8sJQ',
-        'https://www.basestation.nz/en', "0800000577", "info@basestation.nz"),
+        'https://www.basestation.nz/en', '0800000577', 'info@basestation.nz'),
        (2, 'Trustpower', -37.6865807, 176.1649332, 'ChIJgxvxUurYbW0RuC2eHkOaUQA',
-        'https://www.trustpower.co.nz/', "0800878787", "info@trustpower.co.nz"),
+        'https://www.trustpower.co.nz/', '0800878787', 'info@trustpower.co.nz'),
        (3, 'i-SITE', -37.6835924, 176.1677695, 'ChIJn9OKit3bbW0ROSguplmSk5U',
-        'https://www.newzealand.com/in/plan/business/tauranga-i-size-visitor-information-centre/', "075788103", "tauranga@newzealand.com"),
-       (4, 'Tauranga City Library', -37.6828031, 176.1664596, 'ChIJD5sBYefbbW0RP-oj-NNSuoA'
-        'https://library.tauranga.govt.nz/', "075777177", "library@tauranga.govt.nz");
+        'https://www.newzealand.com/in/plan/business/tauranga-i-size-visitor-information-centre/', '075788103', 'tauranga@newzealand.com'),
+       (4, 'Tauranga City Library', -37.6828031, 176.1664596, 'ChIJD5sBYefbbW0RP-oj-NNSuoA',
+        'https://library.tauranga.govt.nz/', '075777177', 'library@tauranga.govt.nz');
 
 INSERT INTO "Challenges" ("Id", "Title", "Description", "Category", "LocationId")
 VALUES (1, 'Day of the Week',


### PR DESCRIPTION
The double quotes around the phone number and email (as well as a missing comma) were stopping the db-seed from running. This should fix it and might be what was causing problems for @hazzery 