### PR TITLE
F/cache auth token

### DIFF
--- a/stem-explorer-ng/src/app/shared/auth/auth.service.ts
+++ b/stem-explorer-ng/src/app/shared/auth/auth.service.ts
@@ -35,7 +35,6 @@ export class AuthService {
   private async getToken() {
     let token = localStorage.token;
     let tokenExpirationTime = localStorage.tokenExpirationTime;
-    console.log(tokenExpirationTime);
     if (!token || Date.parse(tokenExpirationTime) < Date.now()) {
       const user = await this.afAuth.currentUser;
       const res = await user.getIdTokenResult();

--- a/stem-explorer-ng/src/app/shared/auth/auth.service.ts
+++ b/stem-explorer-ng/src/app/shared/auth/auth.service.ts
@@ -33,8 +33,8 @@ export class AuthService {
   }
 
   private async getToken() {
-    let token = localStorage.token;
-    let tokenExpirationTime = localStorage.tokenExpirationTime;
+    let token: string = localStorage.token;
+    let tokenExpirationTime: string = localStorage.tokenExpirationTime;
     if (!token || Date.parse(tokenExpirationTime) < Date.now()) {
       const user = await this.afAuth.currentUser;
       const res = await user.getIdTokenResult();


### PR DESCRIPTION
Use local storage to cache the auth information required to load resources specific to the user. This will decrease the load times by not requiring a request to Google for every page load.