### PR TITLE
Automatically create a profile if one does not exist

### DIFF
--- a/stem-explorer-ng/src/app/core/auth/auth.service.ts
+++ b/stem-explorer-ng/src/app/core/auth/auth.service.ts
@@ -8,6 +8,7 @@ import { ApiService } from 'src/app/shared/services/api.service';
 import { AngularFirestore, AngularFirestoreDocument } from '@angular/fire/firestore';
 import { Router } from '@angular/router';
 import { Profile } from 'src/app/shared/models/profile';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root'
@@ -218,7 +219,21 @@ export class AuthService {
     this.getToken().subscribe(
       () => {
         if (!newUser) {
-          this.getProfile().subscribe();
+          this.getProfile().subscribe({
+            error: async (res: HttpErrorResponse) => {
+              if (res?.status === 404) {
+                const profile: Profile = {
+                  id: null,
+                  email: user.email,
+                  userId: user.uid,
+                  profileCompleted: false,
+                };
+                this.createProfile(profile);
+              } else {
+                console.error(res);
+              }
+            },
+          });
         }
       }
     );


### PR DESCRIPTION
Currently, the code assumes that if the user is already registered on Firebase, then they will have a profile in the DB. This is not always the case.

For instance, let's say I sign into the website hosted on one machine. The auth service recognises that I am a new user and creates me a new profile in the DB. However, when I sign into the website hosted on another machine, the auth service sees that I am already registered with Firebase so it does not create a new profile for me. Then when the auth service tries to get my profile, it fails because there isn't one in the DB on this machine, but still marks me as signed-in. This means that features such as the challenge progress do not work even though we are shown to be signed-in.

The new code automatically creates a new profile *only* if the initial GET /api/Profile returns a 404.