### PR TITLE
Redirect all http requests from Heroku to https

### DIFF
--- a/stem-explorer-ng/nginx/conf.d/default.conf.template
+++ b/stem-explorer-ng/nginx/conf.d/default.conf.template
@@ -1,6 +1,13 @@
 server {
     listen ${PORT};
 
+    # The X-Forwarded-Proto header is set by Heroku to indicate what protocol was used for the original request
+    # https://devcenter.heroku.com/articles/http-routing#heroku-headers
+    if (${DOLLAR}http_x_forwarded_proto = http) {
+        # If the request was forwarded using Heroku from an http url, redirect to the equivalent https url
+        return 301 https://${DOLLAR}host${DOLLAR}request_uri;
+    }
+
     location / {
         root /var/www/html;
 


### PR DESCRIPTION
Please see [this page in the Heroku docs](https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls) for an explanation.

To test this, you can use `curl` to pass additional HTTP headers. Run `docker-compose up explorer_trial_ui` (not docker-compose.dev.yml), and in a new terminal run:

```sh
# Emulates a regular request (eg. on a dev machine)
curl -I http://localhost:4200
# Emulates an HTTPS request through Heroku
curl -H "X-Forwarded-Proto: https" -I http://localhost:4200
# Emulates an HTTP request through Heroku
curl -H "X-Forwarded-Proto: http" -I http://localhost:4200
```

The first two should return output starting with `HTTP/1.1 200 OK`. The last one should output `HTTP/1.1 301 Moved Permanently` and on another line `Location: https://localhost/`, indicating that it would've told the browser to use the HTTPS url.