### PR TITLE
hometown error fixed

### DIFF
--- a/stem-explorer-ng/src/app/containers/profile/profile.component.ts
+++ b/stem-explorer-ng/src/app/containers/profile/profile.component.ts
@@ -60,6 +60,7 @@ export class ProfileComponent implements OnInit {
   regionChange({ value }: { value: string }) {
     this.cities =
       this.regions.find((region) => region.name === value)?.cities ?? [];
+    this.profileForm.controls.homeTown.setValue(null);
   }
 
   toMap() {


### PR DESCRIPTION
Clears the hometown field if user tries to change their region so that form cannot be submitted with incorrect hometown.