### PR TITLE
Prefer the first camera to failing

### DIFF
--- a/stem-explorer-ng/src/app/core/components/camera/camera.component.ts
+++ b/stem-explorer-ng/src/app/core/components/camera/camera.component.ts
@@ -39,7 +39,7 @@ export class CameraComponent {
         return;
       }
     });
-    this.currentDevice = devices[1] || null;
+    this.currentDevice = devices[1] || devices[0] || null;
     console.warn('selected device', this.currentDevice);
   }
 


### PR DESCRIPTION
If the user only has one camera, then use that camera instead of nothing.