### PR TITLE
Invalidate location data when level is completed

### DIFF
--- a/stem-explorer-ng/src/challenge/components/challenge-view/challenge-view.component.ts
+++ b/stem-explorer-ng/src/challenge/components/challenge-view/challenge-view.component.ts
@@ -13,6 +13,8 @@ import { AnswerDialogComponent } from '../answer-dialog/answer-dialog.component'
 import { HintDialogComponent } from '../hint-dialog/hint-dialog.component';
 import { ResultDialogComponent } from '../result-dialog/result-dialog.component';
 import { LargeCategoryIcons } from 'src/app/shared/enums/large-category-icons.enum';
+import { Store } from '@ngxs/store';
+import { InvalidateLocationsData } from 'src/locations/store/locations.actions';
 
 @Component({
   selector: 'app-challenge-view',
@@ -37,6 +39,7 @@ export class ChallengeViewComponent implements OnInit {
     private api: ChallengeApiService,
     private gtmService: GoogleTagManagerService,
     private authService: AuthService,
+    private store: Store,
   ) {
     this.challengeId = +this.route.snapshot.params['id'];
     this.profile = JSON.parse(localStorage.getItem('profile'));
@@ -132,6 +135,7 @@ export class ChallengeViewComponent implements OnInit {
       await this.api
         .levelCompleted(token, this.profile.id, this.selectedLevel.id, result)
         .toPromise();
+      this.store.dispatch(new InvalidateLocationsData());
     } else if (result) {
       this.authService.recordGuestCompleted(this.selectedLevel.id);
     }

--- a/stem-explorer-ng/src/locations/store/locations.actions.ts
+++ b/stem-explorer-ng/src/locations/store/locations.actions.ts
@@ -1,3 +1,7 @@
 export class LoadLocationsData {
   public static type = 'LoadLocationsData';
 }
+
+export class InvalidateLocationsData {
+  public static type = 'InvalidateLocationsData';
+}

--- a/stem-explorer-ng/src/locations/store/locations.state.ts
+++ b/stem-explorer-ng/src/locations/store/locations.state.ts
@@ -3,7 +3,7 @@ import { Action, Selector, State, StateContext, StateToken } from '@ngxs/store';
 import { tap } from 'rxjs/operators';
 import { Location } from '../models/location';
 import { LocationApiService } from '../services/locations-api.service';
-import { LoadLocationsData } from './locations.actions';
+import { InvalidateLocationsData, LoadLocationsData } from './locations.actions';
 
 export interface LocationsStateModel {
   locations: Location[];
@@ -46,5 +46,10 @@ export class LocationsState {
         )
       );
     }
+  }
+
+  @Action(InvalidateLocationsData)
+  public invaidateData(ctx: StateContext<LocationsStateModel>) {
+    ctx.patchState({ fetched: false });
   }
 }


### PR DESCRIPTION
When the user completes a challenge, mark the locations data as needing to be fetched again