### PR TITLE
Remove map icons when filter is changed (b/map-performance)

### DIFF
--- a/stem-explorer-ng/src/locations/components/map/map2.component.ts
+++ b/stem-explorer-ng/src/locations/components/map/map2.component.ts
@@ -56,6 +56,10 @@ export class Map2Component implements OnInit, AfterViewInit {
           lat: pos.lat,
           lng: pos.lng
         };
+
+        if (this.userMarker) {
+          this.userMarker.setPosition(pos);
+        }
       }
     });
 
@@ -194,8 +198,6 @@ export class Map2Component implements OnInit, AfterViewInit {
         map: this.map,
         icon: '/assets/icons/personMarker.png'
       });
-    } else {
-      this.userMarker.setPosition(this.userLocation);
     }
     this.userMarker.setMap(this.map);
 

--- a/stem-explorer-ng/src/locations/components/map/map2.component.ts
+++ b/stem-explorer-ng/src/locations/components/map/map2.component.ts
@@ -25,6 +25,7 @@ export class Map2Component implements OnInit, AfterViewInit {
   @ViewChild('infoWindow', { static: false }) infoWindow: google.maps.InfoWindow;
   map: google.maps.Map;
   markers: any[] = [];
+  markersMap = new Map<number, google.maps.Marker>();
 
   filter: Filter;
   locations: Location[];
@@ -154,6 +155,10 @@ export class Map2Component implements OnInit, AfterViewInit {
 
     const filtered = this.filterLocations.transform(this.locations, this.filter);
     filtered.forEach(loc => {
+      if (this.markersMap.has(loc.uid)) {
+        // Don't create duplicate markers
+        return;
+      }
 
       const marker = new google.maps.Marker({
         position: new google.maps.LatLng(loc.position),
@@ -169,6 +174,7 @@ export class Map2Component implements OnInit, AfterViewInit {
         this.clickOnMarker(marker, loc);
       });
 
+      this.markersMap.set(loc.uid, marker);
       this.markers.push(marker);
     });
 


### PR DESCRIPTION
- Remove map icons when filter is changed
- Prevent the creation of duplicate markers