### PR TITLE
Automatically embed YouTube videos

### DIFF
--- a/StemExplorerAPI/StemExplorerAPI/Migrations/20201006045824_AddVideoEmbedUrl.Designer.cs
+++ b/StemExplorerAPI/StemExplorerAPI/Migrations/20201006045824_AddVideoEmbedUrl.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using StemExplorerAPI.Models;
@@ -10,9 +11,10 @@ using StemExplorerAPI.Models;
 namespace StemExplorerAPI.Migrations
 {
     [DbContext(typeof(StemExplorerContext))]
-    partial class StemExplorerContextModelSnapshot : ModelSnapshot
+    [Migration("20201006045824_AddVideoEmbedUrl")]
+    partial class AddVideoEmbedUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/StemExplorerAPI/StemExplorerAPI/Migrations/20201006045824_AddVideoEmbedUrl.cs
+++ b/StemExplorerAPI/StemExplorerAPI/Migrations/20201006045824_AddVideoEmbedUrl.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace StemExplorerAPI.Migrations
+{
+    public partial class AddVideoEmbedUrl : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "VideoEmbedUrl",
+                table: "ChallengeLevels",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "VideoEmbedUrl",
+                table: "ChallengeLevels");
+        }
+    }
+}

--- a/StemExplorerAPI/StemExplorerAPI/Models/Entities/ChallengeLevel.cs
+++ b/StemExplorerAPI/StemExplorerAPI/Models/Entities/ChallengeLevel.cs
@@ -13,6 +13,7 @@ namespace StemExplorerAPI.Models.Entities
         public string Instructions { get; set; }
         public Enums.AnswerType AnswerType { get; set; }
         public string Hint { get; set; }
+        public string VideoEmbedUrl { get; set; }
 
         public List<string> PossibleAnswers { get; set; }
         public List<string> Answers { get; set; }

--- a/StemExplorerAPI/StemExplorerAPI/Models/ViewModels/ChallengeDto.cs
+++ b/StemExplorerAPI/StemExplorerAPI/Models/ViewModels/ChallengeDto.cs
@@ -28,5 +28,6 @@ namespace StemExplorerAPI.Models.ViewModels
         public List<string> PossibleAnswers { get; set; }
         public List<string> Answer { get; set; }
         public bool Complete { get; set; }
+        public string VideoEmbedUrl { get; set; }
     }
 }

--- a/StemExplorerAPI/StemExplorerAPI/Models/ViewModels/ChallengeLevelDto.cs
+++ b/StemExplorerAPI/StemExplorerAPI/Models/ViewModels/ChallengeLevelDto.cs
@@ -21,5 +21,6 @@ namespace StemExplorerAPI.Models.ViewModels
         public int ChallengeId { get; set; }
         public string Hint { get; set; }
         public bool Complete { get; set; }
+        public string VideoEmbedUrl { get; set; }
     }
 }

--- a/StemExplorerAPI/StemExplorerAPI/Services/ChallengeLevelService.cs
+++ b/StemExplorerAPI/StemExplorerAPI/Services/ChallengeLevelService.cs
@@ -37,6 +37,7 @@ namespace StemExplorerAPI.Services
                     ChallengeId = l.ChallengeId,
                     Hint = l.Hint,
                     Complete = false,
+                    VideoEmbedUrl = l.VideoEmbedUrl,
                 })
                 .OrderBy(l => l.Difficulty)
                 .ToListAsync();
@@ -69,6 +70,7 @@ namespace StemExplorerAPI.Services
                     Answers = l.Answers,
                     ChallengeId = l.ChallengeId,
                     Hint = l.Hint,
+                    VideoEmbedUrl = l.VideoEmbedUrl,
                 })
                 .ToListAsync();
 

--- a/StemExplorerAPI/StemExplorerAPI/Services/ChallengeService.cs
+++ b/StemExplorerAPI/StemExplorerAPI/Services/ChallengeService.cs
@@ -16,13 +16,11 @@ namespace StemExplorerAPI.Services
         private readonly StemExplorerContext _context;
         private readonly ILogger _logger;
         private readonly IProgressService _progressService;
-        private readonly IChallengeLevelService _challengeLevelService;
-        public ChallengeService(StemExplorerContext context, ILogger<ChallengeService> logger, IProgressService progressService, IChallengeLevelService challengeLevelService)
+        public ChallengeService(StemExplorerContext context, ILogger<ChallengeService> logger, IProgressService progressService)
         {
             _context = context;
             _logger = logger;
             _progressService = progressService;
-            _challengeLevelService = challengeLevelService;
         }
 
         public async Task<List<ChallengeDto>> GetChallenges(int? profileId)

--- a/stem-explorer-ng/src/challenge/components/challenge-view/challenge-view.component.html
+++ b/stem-explorer-ng/src/challenge/components/challenge-view/challenge-view.component.html
@@ -40,7 +40,9 @@
     <h4>Question</h4>
     <p>{{ selectedLevel.question }}</p>
   </ng-container>
-  
+
+  <iframe class="level-video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/FCFWu4NlUJQ"></iframe>
+
   <h3 [class]="Colour[challenge.category] + ' center'" *ngIf="selectedLevel.complete">Awesome work! You've completed this level!</h3>
 
   <app-button

--- a/stem-explorer-ng/src/challenge/components/challenge-view/challenge-view.component.html
+++ b/stem-explorer-ng/src/challenge/components/challenge-view/challenge-view.component.html
@@ -41,7 +41,7 @@
     <p>{{ selectedLevel.question }}</p>
   </ng-container>
 
-  <iframe class="level-video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/FCFWu4NlUJQ"></iframe>
+  <iframe *ngIf="selectedLevel.videoEmbedUrl" class="level-video" width="560" height="315" [src]="selectedLevel.videoEmbedUrl" allowfullscreen></iframe>
 
   <h3 [class]="Colour[challenge.category] + ' center'" *ngIf="selectedLevel.complete">Awesome work! You've completed this level!</h3>
 

--- a/stem-explorer-ng/src/challenge/components/challenge-view/challenge-view.component.scss
+++ b/stem-explorer-ng/src/challenge/components/challenge-view/challenge-view.component.scss
@@ -104,3 +104,9 @@ app-form-field {
     }
   }
 }
+
+.level-video {
+  border: none;
+  max-width: 100%;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+}

--- a/stem-explorer-ng/src/challenge/models/challenge.ts
+++ b/stem-explorer-ng/src/challenge/models/challenge.ts
@@ -1,5 +1,6 @@
 import { Levels } from 'src/app/shared/enums/levels.enum';
 import { QuestionType } from 'src/app/shared/enums/answer-type.enum';
+import { SafeResourceUrl } from '@angular/platform-browser';
 
 export interface Challenge {
     id: number;
@@ -20,4 +21,5 @@ export interface ChallengeLevel {
     answer: string[];
     possibleAnswers?: string[];
     complete?: boolean;
+    videoEmbedUrl: SafeResourceUrl;
 }

--- a/stem-explorer-ng/src/challenge/services/challenge-api.service.ts
+++ b/stem-explorer-ng/src/challenge/services/challenge-api.service.ts
@@ -1,12 +1,14 @@
 import { Injectable } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { ApiService } from 'src/app/shared/services/api.service';
 import { Challenge, ChallengeLevel } from '../models/challenge';
 
 @Injectable({ providedIn: 'root' })
 export class ChallengeApiService {
 
-  constructor(private api: ApiService) {}
+  constructor(private api: ApiService, private domSanitizer: DomSanitizer) {}
 
   /**
    * Get challenge from API
@@ -16,6 +18,19 @@ export class ChallengeApiService {
     return this.api.getEntity(
       `Challenges/${id}${profileId ? `?profileId=${profileId}` : ''}`,
       token
+    ).pipe(
+      // Mark the video embed urls as being safe to use in iframes
+      tap((challenge: Challenge) => {
+        if (challenge?.challengeLevels) {
+          for (const level of challenge.challengeLevels) {
+            level.videoEmbedUrl =
+              level.videoEmbedUrl &&
+              this.domSanitizer.bypassSecurityTrustResourceUrl(
+                level.videoEmbedUrl as string
+              );
+          }
+        }
+      }),
     );
   }
 


### PR DESCRIPTION
Show videos that are linked to in hints and challenge instructions on the challenge page, and allow the embed url to be set explicitly in the database.

This feature was suggested [in this PR review](https://github.com/stemwana-youthdev/Explorer-Trail-2020/pull/268#discussion_r496209361).

The code will only infer the video embed url if the value for it in the DB is null. If the value stored in the database is an empty string, then the video embed url will never be filled in and a video will never appear.

The video embed url property could also be used to embed videos from other websites, such as vimeo.