### PR TITLE
Add production CI for Heroku

### DIFF
--- a/.github/workflows/dockerimage-api.yml
+++ b/.github/workflows/dockerimage-api.yml
@@ -17,7 +17,7 @@ on:
     - '!*.md'
 
 jobs:
-  build:
+  build-docker-api:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dockerimage-api.yml
+++ b/.github/workflows/dockerimage-api.yml
@@ -3,7 +3,7 @@ name: API Docker Image CI
 on:
   push:
     branches:
-    - master
+    - develop
     paths:
     - 'StemExplorerAPI/**'
     - '!*.md'
@@ -11,7 +11,7 @@ on:
     - '*'
   pull_request:
     branches:
-    - master
+    - develop
     paths:
     - 'StemExplorerAPI/**'
     - '!*.md'

--- a/.github/workflows/dockerimage-ui.yml
+++ b/.github/workflows/dockerimage-ui.yml
@@ -17,7 +17,7 @@ on:
     - '!*.md'
 
 jobs:
-  build:
+  build-docker-ui:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dockerimage-ui.yml
+++ b/.github/workflows/dockerimage-ui.yml
@@ -3,7 +3,7 @@ name: UI Docker Image CI
 on:
   push:
     branches:
-    - master
+    - develop
     paths:
     - 'stem-explorer-ng/**'
     - '!*.md'
@@ -11,7 +11,7 @@ on:
     - '*'
   pull_request:
     branches:
-    - master
+    - develop
     paths:
     - 'stem-explorer-ng/**'
     - '!*.md'

--- a/.github/workflows/heroku-prod.yml
+++ b/.github/workflows/heroku-prod.yml
@@ -1,0 +1,46 @@
+name: Heroku deploy CI (Prod)
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-prod:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to Heroku Container registry
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: heroku container:login
+
+    - name: Build and push API
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: |
+        cd ./StemExplorerAPI
+        heroku container:push web -a ${{ secrets.HEROKU_PROD_APP_NAME }}-api
+
+    - name: Build and push UI
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: |
+        cd ./stem-explorer-ng
+        heroku container:push web -a ${{ secrets.HEROKU_PROD_APP_NAME }}-ui
+
+    - name: Release API
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: |
+        cd ./StemExplorerAPI
+        heroku container:release web -a ${{ secrets.HEROKU_PROD_APP_NAME }}-api
+
+    - name: Release UI
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: |
+        cd ./stem-explorer-ng
+        heroku container:release web -a ${{ secrets.HEROKU_PROD_APP_NAME }}-ui

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -2,8 +2,8 @@ name: Heroku deploy CI (QA)
 
 on:
   push:
-    tags:
-    - '*'
+    # tags:
+    # - '*'
 
 jobs:
   deploy-qa:

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -1,4 +1,4 @@
-name: Heroku deploy CI
+name: Heroku deploy CI (QA)
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
     - '*'
 
 jobs:
-  build:
+  deploy-qa:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -2,8 +2,8 @@ name: Heroku deploy CI (QA)
 
 on:
   push:
-    # tags:
-    # - '*'
+    branches:
+      - qa
 
 jobs:
   deploy-qa:


### PR DESCRIPTION
This PR modifies the GitHub workflows in the following ways:
* Changes existing references to the `master` to point to `develop`
* Rename existing workflows to avoid confusion
* Change the original `workflows/heroku.yml` to run when any change is made to the `qa` branch
* Add a copy of `workflows/heroku.yml` that runs when any change is made to the `master` branch

Note that tags are no longer needed to trigger deploys. This requirement can easily be added back in.

## Additional steps needed before the new workflow will function

### Heroku
- Create two new new apps `<app-name>-ui` and `<app-name>-api`, replacing `<app-name>` with anything of your choice (I recommend `explorer-trail`, then QA will be trial and prod trail 🤣)
- Copy over the Config Vars from `explorer-trial-ui` and `explorer-trial-api`, respectively
- Setup a new Postgres DB for the API. Remember to change the `ConnectionStrings__StemExplorer` Config Var

### GitHub
- Create a new secret named `HEROKU_PROD_APP_NAME` with the shared part of the names for the new Heroku apps (eg `explorer-trail`)
- Ensure that branches `qa` and `master` exist, and that they have the code that you want for the next deploys (remember to push 😏)
- (Optional) Restrict access to the `qa` branch
- Merge this into develop (will trigger all workflows that I have changed, and allow them to be triggered in the future)